### PR TITLE
Allowing setting of margin values to 0.

### DIFF
--- a/lib/components/chart.js
+++ b/lib/components/chart.js
@@ -41,13 +41,13 @@ Ember.NVD3.ChartComponent = Ember.Component.extend({
   margin: function() {
     var self = this;
     var margins = {};
-    if (self.get('marginTop'))
+    if (self.get('marginTop') !== null)
       margins.top = self.get('marginTop');
-    if (self.get('marginRight'))
+    if (self.get('marginRight') !== null)
       margins.right = self.get('marginRight');
-    if (self.get('marginBottom'))
+    if (self.get('marginBottom') !== null)
       margins.bottom = self.get('marginBottom');
-    if (self.get('marginLeft'))
+    if (self.get('marginLeft') !== null)
       margins.left = self.get('marginLeft');
     return margins;
   }.property('marginTop', 'marginRight','marginBottom','marginLeft'),


### PR DESCRIPTION
Due to the way JS evaluates 0 as false within a conditional, explicitly
testing for a non-null value before applying margin settings. This
allows a user to provide 0 for margin settings.
